### PR TITLE
change the root node of UI auto tree

### DIFF
--- a/src/Infra/CommandHandler/CommandHandlers.cs
+++ b/src/Infra/CommandHandler/CommandHandlers.cs
@@ -39,7 +39,7 @@ namespace WinAppDriver.Infra.CommandHandler
       { Command.SetWindowPosition, new SetWindowPositionHandler() },
       { Command.GetWindowSize, new GetWindowSizeHandler() },
       { Command.SetWindowSize, new SetWindowSizeHandler() },
-      { Command.TakeScreenshot, new TakeScreenshotHandler() },
+      //{ Command.TakeScreenshot, new TakeScreenshotHandler() },
       { Command.ClickOnElement, new ClickHandler() },
       { Command.DevicePushFile, new DevicePushFileHandler() },
       { Command.DevicePullFile, new DevicePullFileHandler() }

--- a/src/Infra/CommandHandler/ICommandHandlers.cs
+++ b/src/Infra/CommandHandler/ICommandHandlers.cs
@@ -35,7 +35,7 @@ namespace WinAppDriver.Infra.CommandHandler
     GetWindowSize,
     GetWindowPosition,
     MaximizeWindow,
-    TakeScreenshot,
+    //TakeScreenshot,
     ClickOnElement,
     DevicePushFile,
     DevicePullFile

--- a/src/Infra/CommandHandler/SessionHandlers.cs
+++ b/src/Infra/CommandHandler/SessionHandlers.cs
@@ -198,22 +198,22 @@ namespace WinAppDriver.Infra.CommandHandler
     }
   }
 
-  class TakeScreenshotHandler : SessionCommandHandlerBase<string>
-  {
-    protected override string ExecuteSessionCommand(ISessionManager sessionManager, ISession session, string elementId)
-    {
-      // bring the root window to top first
-      var windowHandle = session.GetApplicationRoot().UI().NativeWindowHandle;
-      Helper.Helpers.SetForegroundWindow(windowHandle);
-      Helper.Helpers.BringWindowToTop(windowHandle);
+  //class TakeScreenshotHandler : SessionCommandHandlerBase<string>
+  //{
+  //  protected override string ExecuteSessionCommand(ISessionManager sessionManager, ISession session, string elementId)
+  //  {
+  //    // bring the root window to top first
+  //    var windowHandle = session.GetApplicationRoot().UI().NativeWindowHandle;
+  //    Helper.Helpers.SetForegroundWindow(windowHandle);
+  //    Helper.Helpers.BringWindowToTop(windowHandle);
 
-      var element = elementId == null ? session.GetApplicationRoot() : session.FindElement(elementId);
-      var desktopWindow = element.GetDesktopRectangle();
-      var elementWindow = element.GetBoundingRectangle();
-      elementWindow.IntersectsWith(desktopWindow);
-      return session.TakeScreenshot(elementWindow.X, elementWindow.Y, elementWindow.Height, elementWindow.Width);
-    }
-  }
+  //    var element = elementId == null ? session.GetApplicationRoot() : session.FindElement(elementId);
+  //    var desktopWindow = element.GetDesktopRectangle();
+  //    var elementWindow = element.GetBoundingRectangle();
+  //    elementWindow.IntersectsWith(desktopWindow);
+  //    return session.TakeScreenshot(elementWindow.X, elementWindow.Y, elementWindow.Height, elementWindow.Width);
+  //  }
+  //}
 
   class GetWindowSizeHandler : SessionCommandHandlerBase<SizeResult>
   {

--- a/src/Infra/Communication/Application.cs
+++ b/src/Infra/Communication/Application.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) https://github.com/licanhua/YWinAppDriver. All rights reserved.
 // Licensed under the MIT License.
 
+using Microsoft.Windows.Apps.Test.Foundation;
 using System.Collections.Generic;
 using System.Diagnostics;
 
@@ -25,6 +26,19 @@ namespace WinAppDriver.Infra.Communication
     public int GetProcessId()
     {
       return _processId;
+    }
+
+    public void SetApplicationRoot(UIObject newRoot)
+    {
+      if (newRoot.Name == "Bean UI BHSNB01")
+      {
+        _appRoot = new Element(newRoot);
+      }
+      else if(newRoot.Name == "LoginWindow")
+      {
+        _appRoot = new Element(newRoot);
+      }
+      
     }
 
     public void QuitApplication()

--- a/src/Infra/Communication/ApplicationMananger.cs
+++ b/src/Infra/Communication/ApplicationMananger.cs
@@ -45,37 +45,37 @@ namespace WinAppDriver.Infra.Communication
 
 
     // refer https://github.com/microsoft/microsoft-ui-xaml/blob/40531c714f8003bf0d341a0729fa04dd2ed87710/test/testinfra/MUXTestInfra/Infra/Application.cs#L269
-    public IApplication LaunchModernApp(string appName, string arguments, string forceMatchClassName,
-      string forceMatchAppTitle)
-    {
-      UICondition condition = UICondition.CreateFromClassName("ApplicationFrameWindow")
-        .OrWith(UICondition.CreateFromClassName("Windows.UI.Core.CoreWindow"))
-        .OrWith(UICondition.CreateFromClassName("WinUIDesktopWin32WindowClass"));
+    //public IApplication LaunchModernApp(string appName, string arguments, string forceMatchClassName,
+    //  string forceMatchAppTitle)
+    //{
+    //  UICondition condition = UICondition.CreateFromClassName("ApplicationFrameWindow")
+    //    .OrWith(UICondition.CreateFromClassName("Windows.UI.Core.CoreWindow"))
+    //    .OrWith(UICondition.CreateFromClassName("WinUIDesktopWin32WindowClass"));
 
-      var forceMatch = GetForceMatchCondition(forceMatchAppTitle, forceMatchClassName);
-      if (forceMatch != null)
-      {
-        condition = condition.OrWith(forceMatch);
-      }
+    //  var forceMatch = GetForceMatchCondition(forceMatchAppTitle, forceMatchClassName);
+    //  if (forceMatch != null)
+    //  {
+    //    condition = condition.OrWith(forceMatch);
+    //  }
 
-      try
-      {
-        var launchedApp = ModernAppManager.Launch(appName, arguments, condition);
+    //  try
+    //  {
+    //    var launchedApp = ModernAppManager.Launch(appName, arguments, condition);
 
-        var coreWindow = UIObjectHelpers.GetTopLevelUIObject(launchedApp,
-          new[] { UIObjectHelpers.UWP_CLASS_NAME, UIObjectHelpers.WINUI_CLASS_NAME, UIObjectHelpers.WINTOP_CLASS_NAME });
-        var rootWindow = GetTopLevelWindow(coreWindow);
+    //    var coreWindow = UIObjectHelpers.GetTopLevelUIObject(launchedApp,
+    //      new[] { UIObjectHelpers.UWP_CLASS_NAME, UIObjectHelpers.WINUI_CLASS_NAME, UIObjectHelpers.WINTOP_CLASS_NAME });
+    //    var rootWindow = GetTopLevelWindow(coreWindow);
 
-        return new Application(new Element(rootWindow), coreWindow.ProcessId);
-      }
-      catch
-      {
-        // dump ui object tree to make debugging easier
-        UIObjectHelpers.LogObjectTree(UIObject.Root);
+    //    return new Application(new Element(rootWindow), coreWindow.ProcessId);
+    //  }
+    //  catch
+    //  {
+    //    // dump ui object tree to make debugging easier
+    //    UIObjectHelpers.LogObjectTree(UIObject.Root);
 
-        throw;
-      }
-    }
+    //    throw;
+    //  }
+    //}
 
     public IApplication LaunchLegacyApp(string filename, string arguments, string workingDirectory,
       string forceMatchAppTitle, string forceMatchClassName)
@@ -132,23 +132,24 @@ namespace WinAppDriver.Infra.Communication
         }
       }
 
-      var condition = UICondition.Create(UIProperty.Get(ActionStrings.ProcessId), process.Id);
-      if (forceMatch != null)
-      {
-        condition = condition.OrWith(forceMatch);
-      }
+      //var condition = UICondition.Create(UIProperty.Get(ActionStrings.ProcessId), process.Id);
+      //if (forceMatch != null)
+      //{
+      //  condition = condition.OrWith(forceMatch);
+      //}
 
-      var matched = UIObject.Root.Children.FindMultiple(condition).FirstOrDefault();
-      if (matched != null)
-      {
-        var root = GetTopLevelWindow(matched);
-        return new Application(new Element(root), process.Id);
-      }
-      else
-      {
-        process.Kill();
-        throw new AppLaunchException("Process was created, but fail to match a window");
-      }
+      //var matched = UIObject.Root.Children.FindMultiple(condition).FirstOrDefault();
+      //if (matched != null)
+      //{
+      //  var root = GetTopLevelWindow(matched);
+      //  return new Application(new Element(root), process.Id);
+      //}
+      //else
+      //{
+      //  process.Kill();
+      //  throw new AppLaunchException("Process was created, but fail to match a window");
+      //}
+      throw new AppLaunchException("Process was created, but fail to match a window");
     }
 
 
@@ -156,47 +157,47 @@ namespace WinAppDriver.Infra.Communication
     {
       var app = capabilities.app;
 
-      // Root means the the Windows desktop. It allows user to manipute all applications in Windows
-      // refer https://github.com/microsoft/WinAppDriver/blob/master/Samples/C%23/CortanaTest/BingSearch.cs
-      if (app == "Root")
-      {
-        var attachToTopLevelWindowClassName = capabilities.attachToTopLevelWindowClassName;
+      //// Root means the the Windows desktop. It allows user to manipute all applications in Windows
+      //// refer https://github.com/microsoft/WinAppDriver/blob/master/Samples/C%23/CortanaTest/BingSearch.cs
+      //if (app == "Root")
+      //{
+      //  var attachToTopLevelWindowClassName = capabilities.attachToTopLevelWindowClassName;
 
-        Debug.WriteLine("LaunchApplication attach to " + attachToTopLevelWindowClassName == null
-          ? "Root"
-          : "window with ClassName" + attachToTopLevelWindowClassName);
+      //  Debug.WriteLine("LaunchApplication attach to " + attachToTopLevelWindowClassName == null
+      //    ? "Root"
+      //    : "window with ClassName" + attachToTopLevelWindowClassName);
 
-        if (String.IsNullOrEmpty(attachToTopLevelWindowClassName))
-        {
-          return new Application(new Element(UIObject.Root), UIObject.Root.ProcessId, false);
-        }
-        else
-        {
-          var condition = UICondition.CreateFromClassName(attachToTopLevelWindowClassName);
-          var matched = UIObject.Root.Children.FindMultiple(condition).FirstOrDefault();
-          if (matched == null)
-          {
-            throw new AppLaunchException("There is no window match with class name " +
-                                         attachToTopLevelWindowClassName);
-          }
-          else
-          {
-            return new Application(new Element(matched), matched.ProcessId, false);
-          }
-        }
-      }
-      else if (app.Contains("!"))
-      {
-        Debug.WriteLine("Start UWPApp " + app);
-        return LaunchModernApp(capabilities.app, capabilities.appArguments, capabilities.forceMatchClassName,
-          capabilities.forceMatchAppTitle);
-      }
-      else
-      {
+      //  if (String.IsNullOrEmpty(attachToTopLevelWindowClassName))
+      //  {
+      //    return new Application(new Element(UIObject.Root), UIObject.Root.ProcessId, false);
+      //  }
+      //  else
+      //  {
+      //    var condition = UICondition.CreateFromClassName(attachToTopLevelWindowClassName);
+      //    var matched = UIObject.Root.Children.FindMultiple(condition).FirstOrDefault();
+      //    if (matched == null)
+      //    {
+      //      throw new AppLaunchException("There is no window match with class name " +
+      //                                   attachToTopLevelWindowClassName);
+      //    }
+      //    else
+      //    {
+      //      return new Application(new Element(matched), matched.ProcessId, false);
+      //    }
+      //  }
+      //}
+      //else if (app.Contains("!"))
+      //{
+      //  Debug.WriteLine("Start UWPApp " + app);
+      //  return LaunchModernApp(capabilities.app, capabilities.appArguments, capabilities.forceMatchClassName,
+      //    capabilities.forceMatchAppTitle);
+      //}
+      //else
+      //{
         Debug.WriteLine("Start Legacy app " + capabilities.ToString());
         return LaunchLegacyApp(app, capabilities.appArguments, capabilities.appWorkingDir,
           capabilities.forceMatchAppTitle, capabilities.forceMatchClassName);
-      }
+      //}
     }
   }
 }

--- a/src/Infra/Communication/IApplication.cs
+++ b/src/Infra/Communication/IApplication.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) https://github.com/licanhua/YWinAppDriver. All rights reserved.
 // Licensed under the MIT License.
 
+using Microsoft.Windows.Apps.Test.Foundation;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -10,6 +11,7 @@ namespace WinAppDriver.Infra.Communication
   {
     public int GetProcessId();
     public IElement GetApplicationRoot();
+    public void SetApplicationRoot(UIObject applicationRoot);
     public void QuitApplication();
   }
 

--- a/src/Infra/ISession.cs
+++ b/src/Infra/ISession.cs
@@ -31,6 +31,6 @@ namespace WinAppDriver.Infra
     public string GetWindowHandle();
     public IEnumerable<string> GetWindowHandles();
     public IElement GetWindow(string windowId);
-    public string TakeScreenshot(int x, int y, int height, int width);
+    //public string TakeScreenshot(int x, int y, int height, int width);
   }
 }

--- a/src/Infra/Session.cs
+++ b/src/Infra/Session.cs
@@ -261,8 +261,9 @@ namespace WinAppDriver.Infra
     private void SaveWindowToCache(string key, IElement element)
     {
       _cache.AddWindow(key, element);
-      //刷新元素缓存
-      DFS(element);
+      //不刷新元素缓存，更新根节点
+      _application.SetApplicationRoot((UIObject)(element.GetUIObject()));
+      //DFS(element);
     }
 
     public string GetWindowHandle()
@@ -305,24 +306,24 @@ namespace WinAppDriver.Infra
       }
     }
 
-    public string TakeScreenshot(int x, int y, int height, int width)
-    {
-      x = Math.Max(0, x);
-      y = Math.Max(0, y);
-      height = Math.Max(1, height);
-      width = Math.Max(1, width);
-      using var bitmap = new Bitmap(width, height);
-      using (var g = Graphics.FromImage(bitmap))
-      {
-        g.CopyFromScreen(x, y, 0, 0,
-        bitmap.Size, CopyPixelOperation.SourceCopy);
-      }
+    //public string TakeScreenshot(int x, int y, int height, int width)
+    //{
+    //  x = Math.Max(0, x);
+    //  y = Math.Max(0, y);
+    //  height = Math.Max(1, height);
+    //  width = Math.Max(1, width);
+    //  using var bitmap = new Bitmap(width, height);
+    //  using (var g = Graphics.FromImage(bitmap))
+    //  {
+    //    g.CopyFromScreen(x, y, 0, 0,
+    //    bitmap.Size, CopyPixelOperation.SourceCopy);
+    //  }
 
-      using (MemoryStream ms = new MemoryStream())
-      {
-        bitmap.Save(ms, ImageFormat.Png);
-        return System.Convert.ToBase64String(ms.ToArray());
-      }
-    }
+    //  using (MemoryStream ms = new MemoryStream())
+    //  {
+    //    bitmap.Save(ms, ImageFormat.Png);
+    //    return System.Convert.ToBase64String(ms.ToArray());
+    //  }
+    //}
   }
 }

--- a/src/WinAppDriver/Controllers/SessionController.cs
+++ b/src/WinAppDriver/Controllers/SessionController.cs
@@ -323,19 +323,19 @@ namespace WinAppDriver.Controllers
       return ExecuteCommand(Command.AppiumLaunchApp, sessionId, null, null);
     }
 
-    [HttpGet]
-    [Route("{sessionId}/screenshot")]
-    public IActionResult TakeScreenshot(string sessionId)
-    {
-      return ExecuteCommand(Command.TakeScreenshot, sessionId, null, null);
-    }
+    //[HttpGet]
+    //[Route("{sessionId}/screenshot")]
+    //public IActionResult TakeScreenshot(string sessionId)
+    //{
+    //  return ExecuteCommand(Command.TakeScreenshot, sessionId, null, null);
+    //}
 
-    [HttpGet]
-    [Route("{sessionId}/element/{elementId}/screenshot")]
-    public IActionResult TakeScreenshot(string sessionId, string elementId)
-    {
-      return ExecuteCommand(Command.TakeScreenshot, sessionId, null, elementId);
-    }
+    //[HttpGet]
+    //[Route("{sessionId}/element/{elementId}/screenshot")]
+    //public IActionResult TakeScreenshot(string sessionId, string elementId)
+    //{
+    //  return ExecuteCommand(Command.TakeScreenshot, sessionId, null, elementId);
+    //}
 
     [HttpPost]
     [Route("{sessionId}/timeouts/async_script")]


### PR DESCRIPTION
do not update elements cache when switch to new window, instead change the root node of UI auto tree.

remove screen shot function and launch the root app or include "!" app function.